### PR TITLE
Add Studio REST API, UI sync, retries, and context-aware sticker flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Gemini / Google AI
 GEMINI_API_KEY=your-gemini-api-key-here
 GEMINI_MODEL=gemini-2.5-flash
+# Optional: used when the primary model returns 503/429 (high demand). Try e.g. gemini-2.0-flash
+# GEMINI_MODEL_FALLBACK=gemini-2.0-flash
+
+# Optional: image gen model fallback (same transient errors as chat)
+# GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
+# GEMINI_IMAGE_MODEL_FALLBACK=
 
 # YouTube Data API v3 (optional — enables video stats)
 # YOUTUBE_API_KEY=your-youtube-api-key

--- a/agents/community_agent.py
+++ b/agents/community_agent.py
@@ -26,6 +26,7 @@ from pydantic_ai.providers.google import GoogleProvider
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from schemas.community import CommunityAnalysis
+from utils.llm_retry import sync_retry_llm
 
 load_dotenv()
 
@@ -117,5 +118,5 @@ def analyze_community_text(mined_data: dict) -> CommunityAnalysis:
     )
 
     user_prompt = "".join(prompt_parts)
-    result = community_agent.run_sync(user_prompt)
+    result = sync_retry_llm(lambda: community_agent.run_sync(user_prompt))
     return result.output

--- a/agents/design_agent.py
+++ b/agents/design_agent.py
@@ -19,6 +19,7 @@ from pydantic_ai.providers.google import GoogleProvider
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from schemas.design import DesignSpec
+from utils.llm_retry import sync_retry_llm
 
 load_dotenv()
 DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
@@ -76,7 +77,7 @@ def generate_design_spec(
         "It must be Cricut-compatible (clean edges, transparent background)."
     )
 
-    result = design_agent.run_sync("\n\n".join(parts))
+    result = sync_retry_llm(lambda: design_agent.run_sync("\n\n".join(parts)))
     return result.output
 
 

--- a/agents/image_gen_agent.py
+++ b/agents/image_gen_agent.py
@@ -24,8 +24,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
+from utils.llm_retry import is_transient_gemini_error, sync_retry_llm
+
 # Nano Banana image gen models available on this API key
 IMAGE_MODEL = os.getenv("GEMINI_IMAGE_MODEL", "gemini-2.5-flash-image")
+IMAGE_MODEL_FALLBACK = os.getenv("GEMINI_IMAGE_MODEL_FALLBACK", "").strip()
 
 # Default output directory
 OUTPUT_DIR = Path(__file__).resolve().parent.parent / "outputs" / "stickers"
@@ -63,13 +66,26 @@ def generate_sticker_image(
         "no complex backgrounds, strong clean edges suitable for printing, high contrast."
     )
 
-    response = client.models.generate_content(
-        model=model,
-        contents=full_prompt,
-        config=types.GenerateContentConfig(
-            response_modalities=["TEXT", "IMAGE"],
-        ),
-    )
+    def _call(m: str):
+        return client.models.generate_content(
+            model=m,
+            contents=full_prompt,
+            config=types.GenerateContentConfig(
+                response_modalities=["TEXT", "IMAGE"],
+            ),
+        )
+
+    try:
+        response = sync_retry_llm(lambda: _call(model))
+    except Exception as e:
+        if (
+            IMAGE_MODEL_FALLBACK
+            and IMAGE_MODEL_FALLBACK != model
+            and is_transient_gemini_error(e)
+        ):
+            response = sync_retry_llm(lambda: _call(IMAGE_MODEL_FALLBACK))
+        else:
+            raise
 
     # Find the image part in the response
     image_saved = False

--- a/agents/sticker_idea_agent.py
+++ b/agents/sticker_idea_agent.py
@@ -18,7 +18,8 @@ from pydantic_ai.providers.google import GoogleProvider
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from schemas.sticker import StickerIdeaSet
+from schemas.sticker import PhraseOptionSet, StickerIdeaSet
+from utils.llm_retry import sync_retry_llm
 
 load_dotenv()
 DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
@@ -26,6 +27,11 @@ DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 SYSTEM_PROMPT = """\
 You are a creative director for a sticker design studio that turns viral internet moments into
 sellable merchandise. You understand both internet culture AND visual design.
+
+When the user provides a PARENT TOPIC (e.g. a TV show, festival, artist, game), you MUST keep designs
+anchored in that universe: use its recognizable aesthetic, color grading, fashion era, and
+character archetypes. For example, if the parent is a TV drama, reference how characters actually
+look and dress on that show — do not reduce the idea to a generic literal reading of a meme phrase.
 
 Given a viral bite (a quote, catchphrase, lyric, or meme concept), generate 3-5 distinct sticker
 concepts. Each concept should be a different creative interpretation:
@@ -36,10 +42,12 @@ concepts. Each concept should be a different creative interpretation:
 - Consider what sells on Redbubble and Etsy — clean designs, readable text, strong silhouettes
 
 For text-only stickers, focus on typography and lettering style.
-For image stickers, describe the visual in enough detail for an AI image generator.
+For image stickers, describe the visual in enough detail for an AI image generator (who/what is on
+the sticker, pose, wardrobe cues tied to the parent topic when relevant).
 For text+image combos, describe how text and image interact.
 
-Suggest specific color palettes that match the vibe of the viral moment.\
+Suggest specific color palettes that match the vibe of the viral moment AND the parent topic when one
+is given.\
 """
 
 
@@ -57,18 +65,60 @@ sticker_idea_agent = Agent(
     output_type=StickerIdeaSet,
 )
 
+PHRASE_SYSTEM_PROMPT = """\
+You propose short text options for print-on-demand stickers (1–6 words each when possible).
+
+Rules:
+- Output exactly 5 phrases.
+- Each phrase must be DISTINCT (different wording, angle, or tone — never the same line repeated).
+- When a parent topic is given (TV show, game, artist, event), phrases should feel native to that world.
+- Phrases are the product copy only — not art direction (no "in kawaii style").
+"""
+
+
+phrase_options_agent = Agent(
+    model=_build_model(),
+    system_prompt=PHRASE_SYSTEM_PROMPT,
+    output_type=PhraseOptionSet,
+)
+
 
 def generate_sticker_ideas(
     viral_bite: str,
     context: str = "",
 ) -> StickerIdeaSet:
     """Generate sticker concepts from a viral bite."""
-    parts = [f'Viral bite: "{viral_bite}"']
+    parts = [f'Viral bite / moment: "{viral_bite}"']
     if context:
-        parts.append(f"Cultural context: {context}")
-    parts.append("Generate 3-5 distinct sticker design concepts for this viral moment.")
+        parts.append(
+            "Cultural + parent context (franchise, event, aesthetic — use this to ground visuals): "
+            f"{context}"
+        )
+    parts.append(
+        "Generate 3-5 distinct sticker design concepts. If a parent franchise/topic is named in "
+        "context, every visual_description must reflect that world's look and characters, not a "
+        "generic interpretation of the words alone."
+    )
 
-    result = sticker_idea_agent.run_sync("\n\n".join(parts))
+    result = sync_retry_llm(lambda: sticker_idea_agent.run_sync("\n\n".join(parts)))
+    return result.output
+
+
+def suggest_phrase_variants(
+    parent_topic: str,
+    moment: str,
+    trend_context: str = "",
+) -> PhraseOptionSet:
+    """Return 5 distinct phrase options for the Studio phrase-first step."""
+    parts = [f"Trending moment / meme label to riff on: \"{moment}\""]
+    if parent_topic.strip():
+        parts.append(
+            f"Parent topic / franchise (keep tone and references in-universe): {parent_topic.strip()}"
+        )
+    if trend_context.strip():
+        parts.append(f"Signals and evidence: {trend_context.strip()}")
+    parts.append("Produce exactly 5 distinct sticker phrases as specified.")
+    result = sync_retry_llm(lambda: phrase_options_agent.run_sync("\n\n".join(parts)))
     return result.output
 
 

--- a/agents/subtopic_agent.py
+++ b/agents/subtopic_agent.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from schemas.topic import SubtopicResult
 from schemas.trend import TrendReport
+from utils.llm_retry import sync_retry_llm
 
 load_dotenv()
 DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
@@ -122,7 +123,7 @@ def discover_subtopics(
         )
 
     user_prompt = "\n".join(parts)
-    result = subtopic_agent.run_sync(user_prompt)
+    result = sync_retry_llm(lambda: subtopic_agent.run_sync(user_prompt))
     return result.output
 
 

--- a/agents/viral_bite_agent.py
+++ b/agents/viral_bite_agent.py
@@ -20,6 +20,7 @@ from pydantic_ai.providers.google import GoogleProvider
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from schemas.viral import ViralBiteCollection
+from utils.llm_retry import sync_retry_llm
 
 load_dotenv()
 DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
@@ -38,6 +39,12 @@ For each viral bite, assess its monetization potential for sticker designs:
 
 Be specific and exact — quote the actual text people are using, not paraphrases.
 Include the cultural context so a designer understands the reference.\
+
+CRITICAL QUALITY BAR:
+- Prefer EVENT-LEVEL moments (who did what, where/when) over generic topic words.
+- Reject generic fragments like "stage", "vibe", "performance", "festival", "technical issue" unless tied to a concrete incident.
+- Each bite must be understandable as a standalone moment and include a concrete hook.
+- If a candidate is too vague, replace it with a more specific one.
 """
 
 
@@ -73,7 +80,7 @@ def extract_viral_bites(
         "Extract 4-6 viral bites from this subtopic that would make great sticker designs."
     )
 
-    result = viral_bite_agent.run_sync("\n\n".join(parts))
+    result = sync_retry_llm(lambda: viral_bite_agent.run_sync("\n\n".join(parts)))
     return result.output
 
 

--- a/backend/chat_agent.py
+++ b/backend/chat_agent.py
@@ -76,7 +76,8 @@ steer the conversation back toward sticker opportunities.\
 
 DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 
-_agent: Agent | None = None
+# One Agent instance per model name (primary + optional fallback).
+_agents_by_model: dict[str, Agent] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -440,26 +441,46 @@ _TOOLS = [
 ]
 
 
-def get_agent() -> Agent:
-    """Build the chat agent on first call (requires GEMINI_API_KEY)."""
-    global _agent
-    if _agent is not None:
-        return _agent
+def get_agent(model_name: str | None = None) -> Agent:
+    """Build the chat agent for a given model (cached; requires GEMINI_API_KEY)."""
+    name = (model_name or os.getenv("GEMINI_MODEL", "gemini-2.5-flash")).strip()
+    if name in _agents_by_model:
+        return _agents_by_model[name]
 
     api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
     if not api_key:
         raise RuntimeError("Set GEMINI_API_KEY or GOOGLE_API_KEY in .env")
 
     provider = GoogleProvider(api_key=api_key)
-    model = GoogleModel(DEFAULT_MODEL, provider=provider)
+    model = GoogleModel(name, provider=provider)
 
-    _agent = Agent(
+    agent = Agent(
         model=model,
         system_prompt=SYSTEM_PROMPT,
         output_type=str,
     )
 
     for fn in _TOOLS:
-        _agent.tool(fn)
+        agent.tool(fn)
 
-    return _agent
+    _agents_by_model[name] = agent
+    return agent
+
+
+async def run_chat_with_retries(user_prompt: str):
+    """Run the main chat agent with retries and optional model fallback."""
+    from utils.llm_retry import async_retry_llm, is_transient_gemini_error
+
+    primary = os.getenv("GEMINI_MODEL", "gemini-2.5-flash").strip()
+    fallback = os.getenv("GEMINI_MODEL_FALLBACK", "").strip()
+
+    async def run_one(model: str):
+        ag = get_agent(model)
+        return await async_retry_llm(lambda: ag.run(user_prompt))
+
+    try:
+        return await run_one(primary)
+    except Exception as e:
+        if fallback and fallback != primary and is_transient_gemini_error(e):
+            return await run_one(fallback)
+        raise

--- a/backend/server.py
+++ b/backend/server.py
@@ -29,7 +29,9 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 load_dotenv(PROJECT_ROOT / ".env")
 
-from backend.chat_agent import get_agent, _run_in_thread  # noqa: E402
+from pydantic_ai.messages import ToolReturnPart  # noqa: E402
+
+from backend.chat_agent import run_chat_with_retries, _run_in_thread  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # App
@@ -100,24 +102,10 @@ async def chat(req: ChatRequest):
 
         user_prompt = "\n\n".join(parts)
 
-        # Run the agent (async, lazy-built on first call)
-        agent = get_agent()
-        result = await agent.run(user_prompt)
+        # Run the agent with retries + optional fallback model (see .env)
+        result = await run_chat_with_retries(user_prompt)
 
-        # Extract tool call info from the run messages for the frontend
-        tool_results: list[ToolResult] = []
-        for msg in result.all_messages():
-            msg_dict = msg.model_dump() if hasattr(msg, "model_dump") else {}
-            kind = msg_dict.get("kind", "")
-
-            if kind == "tool-return":
-                tool_results.append(
-                    ToolResult(
-                        tool_name=msg_dict.get("tool_name", "unknown"),
-                        args={},
-                        result=_truncate(msg_dict.get("content", ""), max_len=2000),
-                    )
-                )
+        tool_results = _collect_tool_results_from_run(result)
 
         return ChatResponse(
             reply=result.output,
@@ -129,6 +117,111 @@ async def chat(req: ChatRequest):
             reply=f"Something went wrong: {exc}",
             tool_results=[],
         )
+
+
+# ---------------------------------------------------------------------------
+# Sticker Studio — direct pipeline (no chat agent; guaranteed JSON for the UI)
+# ---------------------------------------------------------------------------
+
+
+class StudioBrainstormRequest(BaseModel):
+    parent_topic: str = ""
+    moment: str
+    trend_context: str = ""
+    mode: str = "auto"  # auto | phrase | visual
+
+
+class StudioPhrasesRequest(BaseModel):
+    parent_topic: str = ""
+    moment: str
+    trend_context: str = ""
+
+
+class StudioImageRequest(BaseModel):
+    prompt: str
+    parent_topic: str = ""
+    moment: str = ""
+
+
+def _studio_brainstorm_context(req: StudioBrainstormRequest) -> str:
+    bits: list[str] = []
+    if req.parent_topic.strip():
+        bits.append(f"Parent topic / franchise: {req.parent_topic.strip()}")
+    if req.trend_context.strip():
+        bits.append(f"Signals and evidence: {req.trend_context.strip()}")
+    if req.mode == "visual":
+        bits.append(
+            "Emphasize image-led sticker concepts; tie visuals to the parent topic's aesthetic, "
+            "era, and recognizable character types — not generic stock imagery."
+        )
+    elif req.mode == "phrase":
+        bits.append(
+            "Emphasize text-forward stickers with varied typography treatments; ground copy in the "
+            "parent topic when provided."
+        )
+    else:
+        bits.append(
+            "Balance phrase-led and visual-led concepts; ground all visuals in the parent topic when "
+            "it is provided."
+        )
+    return "\n".join(bits)
+
+
+@app.post("/api/studio/brainstorm")
+async def studio_brainstorm(req: StudioBrainstormRequest):
+    """Run sticker idea generation directly — returns structured ideas for the React Studio."""
+    from agents.sticker_idea_agent import generate_sticker_ideas
+
+    if not req.moment.strip():
+        return JSONResponse({"status": "error", "error": "moment is required"}, status_code=400)
+    try:
+        ctx = _studio_brainstorm_context(req)
+        out = await _run_in_thread(generate_sticker_ideas, req.moment.strip(), ctx)
+        data = out.model_dump()
+        return {"status": "ok", "data": data}
+    except Exception as exc:
+        return JSONResponse({"status": "error", "error": str(exc)}, status_code=500)
+
+
+@app.post("/api/studio/suggest-phrases")
+async def studio_suggest_phrases(req: StudioPhrasesRequest):
+    """Return 5 distinct phrase options for phrase-focused mode."""
+    from agents.sticker_idea_agent import suggest_phrase_variants
+
+    if not req.moment.strip():
+        return JSONResponse({"status": "error", "error": "moment is required"}, status_code=400)
+    try:
+        out = await _run_in_thread(
+            suggest_phrase_variants,
+            req.parent_topic,
+            req.moment.strip(),
+            req.trend_context,
+        )
+        return {"status": "ok", "phrases": out.phrases}
+    except Exception as exc:
+        return JSONResponse({"status": "error", "error": str(exc)}, status_code=500)
+
+
+@app.post("/api/studio/generate-image")
+async def studio_generate_image(req: StudioImageRequest):
+    """Generate a sticker PNG and return filename for the Studio gallery."""
+    from agents.image_gen_agent import generate_sticker_image
+
+    if not req.prompt.strip():
+        return JSONResponse({"status": "error", "error": "prompt is required"}, status_code=400)
+    try:
+        full = req.prompt.strip()
+        if req.parent_topic.strip() or req.moment.strip():
+            full = (
+                f"{full}\n\n"
+                f"Context — parent topic: {req.parent_topic or 'n/a'}; "
+                f"moment: {req.moment or 'n/a'}"
+            )
+        path = await _run_in_thread(generate_sticker_image, full)
+        name = path.name
+        return {"status": "ok", "filename": name, "url": f"/stickers/{name}"}
+    except Exception as exc:
+        return JSONResponse({"status": "error", "error": str(exc)}, status_code=500)
 
 
 # ---------------------------------------------------------------------------
@@ -320,11 +413,38 @@ async def top_trending():
         return {"status": "error", "error": str(exc)}
 
 
-def _truncate(text: str, max_len: int = 2000) -> str:
+def _truncate(text: str, max_len: int = 20000) -> str:
     """Truncate long tool outputs so we don't blow up the response."""
     if len(text) <= max_len:
         return text
     return text[:max_len] + "... (truncated)"
+
+
+def _collect_tool_results_from_run(run_result) -> list[ToolResult]:
+    """Extract tool return payloads from PydanticAI v2 message history.
+
+    Tool outputs live on ModelRequest.parts as ToolReturnPart, not as top-level
+    messages with kind 'tool-return'.
+    """
+    out: list[ToolResult] = []
+    for msg in run_result.all_messages():
+        parts = getattr(msg, "parts", None)
+        if not parts:
+            continue
+        for part in parts:
+            if isinstance(part, ToolReturnPart):
+                try:
+                    body = part.model_response_str()
+                except Exception:
+                    body = str(part.content)
+                out.append(
+                    ToolResult(
+                        tool_name=part.tool_name,
+                        args={},
+                        result=_truncate(body, max_len=20000),
+                    )
+                )
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1083,6 +1084,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1148,6 +1150,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1404,6 +1407,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1537,6 +1541,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -901,6 +901,81 @@ body {
   font-size: 0.85rem;
 }
 
+.studio-note {
+  margin: 0 0 10px 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.1);
+  color: #f59e0b;
+  border-radius: 8px;
+  font-size: 0.8rem;
+}
+
+.studio-mode-select {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 8px;
+  font-size: 0.8rem;
+  padding: 6px 10px;
+}
+
+.studio-parent-topic {
+  margin: 6px 0 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.studio-subheading {
+  font-size: 0.88rem;
+  margin: 10px 0 4px 0;
+  font-weight: 600;
+}
+
+.studio-hint {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 0 0 8px 0;
+}
+
+.studio-phrase-step {
+  margin-bottom: 12px;
+}
+
+.studio-action-btn.secondary {
+  margin-right: 8px;
+  margin-bottom: 8px;
+  background: transparent;
+}
+
+.phrase-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.phrase-chip {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-align: left;
+  max-width: 100%;
+}
+
+.phrase-chip:hover {
+  border-color: var(--accent);
+}
+
+.phrase-chip.selected {
+  border-color: var(--accent);
+  background: rgba(124, 58, 237, 0.12);
+}
+
 /* Viral bites horizontal scroll */
 .bites-scroll {
   display: flex;

--- a/frontend/src/components/StickerStudio.jsx
+++ b/frontend/src/components/StickerStudio.jsx
@@ -1,110 +1,163 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTrend } from '../context/TrendContext'
 
-function extractViralBites(toolResults) {
-  if (!toolResults) return []
-  const bites = []
-  for (const tr of toolResults) {
-    let data = tr.result || tr.data || tr.output || tr
-    if (typeof data === 'string') {
-      try { data = JSON.parse(data) } catch (_) { continue }
-    }
-    if (data && data.viral_bites && Array.isArray(data.viral_bites)) {
-      bites.push(...data.viral_bites)
-    } else if (data && data.bites && Array.isArray(data.bites)) {
-      bites.push(...data.bites)
-    } else if (Array.isArray(data)) {
-      const biteLike = data.filter(d => d && (d.text || d.phrase || d.bite))
-      bites.push(...biteLike)
-    }
-  }
-  return bites
-}
+const API_BASE = 'http://localhost:8000'
 
-function extractStickerConcepts(toolResults) {
-  if (!toolResults) return []
-  const concepts = []
-  for (const tr of toolResults) {
-    let data = tr.result || tr.data || tr.output || tr
-    if (typeof data === 'string') {
-      try { data = JSON.parse(data) } catch (_) { continue }
-    }
-    if (data && data.sticker_ideas && Array.isArray(data.sticker_ideas)) {
-      concepts.push(...data.sticker_ideas)
-    } else if (data && data.ideas && Array.isArray(data.ideas)) {
-      concepts.push(...data.ideas)
-    } else if (data && data.concepts && Array.isArray(data.concepts)) {
-      concepts.push(...data.concepts)
-    } else if (Array.isArray(data)) {
-      const conceptLike = data.filter(d => d && (d.art_style || d.style || d.prompt || d.description))
-      concepts.push(...conceptLike)
-    }
+async function studioPost(path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok || data.status === 'error') {
+    throw new Error(data.error || `Request failed (${res.status})`)
   }
-  return concepts
-}
-
-function extractStickerImage(toolResults) {
-  if (!toolResults) return []
-  const images = []
-  for (const tr of toolResults) {
-    const raw = tr.result || tr.data || tr.output || ''
-    if (typeof raw === 'string') {
-      const match = raw.match(/Sticker image saved to:.*?([^/\\]+\.png)/i)
-      if (match) images.push(match[1])
-      // Also check for just a filename pattern
-      const fnMatch = raw.match(/([a-zA-Z0-9_-]+\.png)/g)
-      if (fnMatch) {
-        for (const fn of fnMatch) {
-          if (!images.includes(fn)) images.push(fn)
-        }
-      }
-    }
-  }
-  return images
+  return data
 }
 
 function StickerStudio({ onNavigateTrends }) {
   const {
-    selectedTrend, setSelectedTrend,
-    viralBites, setViralBites,
+    selectedTrend,
     stickerIdeas, setStickerIdeas,
     generatedStickers, setGeneratedStickers,
-    sendChatMessage, chatLoading,
+    chatLoading,
   } = useTrend()
 
-  const [selectedBite, setSelectedBite] = useState(null)
   const [selectedConcept, setSelectedConcept] = useState(null)
-  const [loadingBites, setLoadingBites] = useState(false)
   const [loadingConcepts, setLoadingConcepts] = useState(false)
+  const [loadingPhrases, setLoadingPhrases] = useState(false)
   const [loadingImage, setLoadingImage] = useState(false)
   const [refinement, setRefinement] = useState('')
+  const [conceptMode, setConceptMode] = useState('auto')
+  const [studioNotice, setStudioNotice] = useState('')
+  const [phraseOptions, setPhraseOptions] = useState([])
+  const [selectedPhraseOption, setSelectedPhraseOption] = useState(null)
 
   const trendName = selectedTrend
     ? (selectedTrend.trend_name || selectedTrend.name || 'selected trend')
     : null
 
-  const handleExtractBites = async () => {
-    if (!trendName || loadingBites) return
-    setLoadingBites(true)
-    const result = await sendChatMessage(`extract viral bites from '${trendName}'`)
-    if (result && result.toolResults) {
-      const parsed = extractViralBites(result.toolResults)
-      if (parsed.length > 0) setViralBites(parsed)
+  const parentTopic = selectedTrend?.parent_topic || ''
+  const studioBusy = loadingConcepts || loadingPhrases || loadingImage
+
+  useEffect(() => {
+    setPhraseOptions([])
+    setSelectedPhraseOption(null)
+    setStudioNotice('')
+  }, [selectedTrend?.name, selectedTrend?.trend_name])
+
+  useEffect(() => {
+    if (conceptMode !== 'phrase') {
+      setPhraseOptions([])
+      setSelectedPhraseOption(null)
     }
-    setLoadingBites(false)
+  }, [conceptMode])
+
+  const getTrendContextText = () => {
+    if (!selectedTrend) return ''
+    const desc = selectedTrend.description || ''
+    const evidence = Array.isArray(selectedTrend.evidence) ? selectedTrend.evidence : []
+    const evidenceTitles = evidence
+      .slice(0, 5)
+      .map((e) => e?.title || e?.text || '')
+      .filter(Boolean)
+    const bits = []
+    if (parentTopic) bits.push(`User searched / parent topic: ${parentTopic}`)
+    bits.push(desc, ...evidenceTitles)
+    return bits.filter(Boolean).join(' | ')
   }
 
-  const handleGenerateConcepts = async (bite) => {
-    if (loadingConcepts) return
-    setSelectedBite(bite)
-    setLoadingConcepts(true)
-    const biteText = bite.text || bite.phrase || bite.bite || JSON.stringify(bite)
-    const result = await sendChatMessage(`generate sticker ideas for '${biteText}'`)
-    if (result && result.toolResults) {
-      const parsed = extractStickerConcepts(result.toolResults)
-      if (parsed.length > 0) setStickerIdeas(parsed)
+  const handleSuggestPhrases = async () => {
+    if (!trendName || loadingPhrases) return
+    setLoadingPhrases(true)
+    setStudioNotice('')
+    setPhraseOptions([])
+    try {
+      const data = await studioPost('/api/studio/suggest-phrases', {
+        parent_topic: parentTopic,
+        moment: trendName,
+        trend_context: getTrendContextText(),
+      })
+      const phrases = data.phrases || []
+      if (phrases.length > 0) {
+        setPhraseOptions(phrases)
+        setStudioNotice('Pick one phrase, then click “Brainstorm sticker concepts”.')
+      } else {
+        setStudioNotice('No phrases returned. Try again.')
+      }
+    } catch (e) {
+      setStudioNotice(e.message || 'Could not load phrase options.')
+    } finally {
+      setLoadingPhrases(false)
     }
-    setLoadingConcepts(false)
+  }
+
+  const runAutoImages = async (concepts, momentForContext) => {
+    if (!Array.isArray(concepts) || concepts.length === 0) return 0
+    let n = 0
+    for (const concept of concepts.slice(0, 2)) {
+      const prompt = concept.visual_description || concept.concept_description || concept.prompt || concept.description
+      if (!prompt) continue
+      try {
+        const data = await studioPost('/api/studio/generate-image', {
+          prompt,
+          parent_topic: parentTopic,
+          moment: momentForContext || trendName,
+        })
+        if (data.filename) {
+          n += 1
+          setGeneratedStickers(prev => [...prev, data.filename])
+        }
+      } catch {
+        /* one image failure should not block the rest */
+      }
+    }
+    return n
+  }
+
+  const handleGenerateConceptsFromTrend = async () => {
+    if (!trendName || loadingConcepts) return
+    if (conceptMode === 'phrase' && phraseOptions.length > 0 && !selectedPhraseOption) {
+      setStudioNotice('Select one of the suggested phrases first, or clear phrase options by switching mode.')
+      return
+    }
+    setStudioNotice('')
+    setLoadingConcepts(true)
+    setStickerIdeas([])
+    const momentLabel = conceptMode === 'phrase' && selectedPhraseOption ? selectedPhraseOption : trendName
+    try {
+      const data = await studioPost('/api/studio/brainstorm', {
+        parent_topic: parentTopic,
+        moment: momentLabel,
+        trend_context: getTrendContextText(),
+        mode: conceptMode,
+      })
+      const ideas = data.data?.ideas ?? []
+      if (ideas.length === 0) {
+        setStudioNotice('No concepts returned. Check your API key and try again.')
+        return
+      }
+      const modeFiltered = ideas.filter((idea) => {
+        const layout = idea.layout_type || idea.layout || ''
+        if (conceptMode === 'visual') return layout !== 'text_only'
+        if (conceptMode === 'phrase') return layout !== 'image_only'
+        return true
+      })
+      const finalIdeas = modeFiltered.length > 0 ? modeFiltered : ideas
+      setStickerIdeas(finalIdeas)
+
+      setLoadingImage(true)
+      const created = await runAutoImages(finalIdeas, momentLabel)
+      setLoadingImage(false)
+      if (created > 0) {
+        setStudioNotice(`Generated ${created} sticker preview${created > 1 ? 's' : ''} in step 3.`)
+      }
+    } catch (e) {
+      setStudioNotice(e.message || 'Brainstorm failed.')
+    } finally {
+      setLoadingConcepts(false)
+    }
   }
 
   const handleGenerateImage = async (concept) => {
@@ -112,26 +165,43 @@ function StickerStudio({ onNavigateTrends }) {
     setSelectedConcept(concept)
     setLoadingImage(true)
     const prompt = concept.visual_description || concept.concept_description || concept.prompt || concept.description || JSON.stringify(concept)
-    const result = await sendChatMessage(`generate a sticker image for: ${prompt}`)
-    if (result && result.toolResults) {
-      const images = extractStickerImage(result.toolResults)
-      if (images.length > 0) {
-        setGeneratedStickers(prev => [...prev, ...images])
+    try {
+      const data = await studioPost('/api/studio/generate-image', {
+        prompt,
+        parent_topic: parentTopic,
+        moment: trendName,
+      })
+      if (data.filename) {
+        setGeneratedStickers(prev => [...prev, data.filename])
       }
+    } catch (e) {
+      setStudioNotice(e.message || 'Image generation failed.')
+    } finally {
+      setLoadingImage(false)
     }
-    setLoadingImage(false)
   }
 
   const handleRefinement = async () => {
     if (!refinement.trim()) return
-    const result = await sendChatMessage(refinement)
-    if (result && result.toolResults) {
-      const images = extractStickerImage(result.toolResults)
-      if (images.length > 0) {
-        setGeneratedStickers(prev => [...prev, ...images])
+    setLoadingImage(true)
+    const base = selectedConcept
+      ? `${refinement}\n\nReference concept: ${selectedConcept.visual_description || selectedConcept.concept_description || ''}`
+      : `${refinement}\n\nTopic: ${trendName}${parentTopic ? `; parent: ${parentTopic}` : ''}`
+    try {
+      const data = await studioPost('/api/studio/generate-image', {
+        prompt: base,
+        parent_topic: parentTopic,
+        moment: trendName,
+      })
+      if (data.filename) {
+        setGeneratedStickers(prev => [...prev, data.filename])
       }
+    } catch (e) {
+      setStudioNotice(e.message || 'Refinement failed.')
+    } finally {
+      setLoadingImage(false)
+      setRefinement('')
     }
-    setRefinement('')
   }
 
   if (!selectedTrend) {
@@ -150,61 +220,77 @@ function StickerStudio({ onNavigateTrends }) {
       <div className="studio-header">
         <button className="back-link" onClick={onNavigateTrends}>&larr; Back to Trends</button>
         <h2>Creating stickers for: <span className="studio-trend-name">{trendName}</span></h2>
+        {parentTopic && (
+          <p className="studio-parent-topic">Parent topic: <strong>{parentTopic}</strong></p>
+        )}
       </div>
 
-      {/* Step 1: Viral Bites */}
       <section className="studio-section">
         <div className="studio-section-header">
-          <h3><span className="step-num">1</span> Viral Bites</h3>
-          {viralBites.length === 0 && (
-            <button className="studio-action-btn" onClick={handleExtractBites} disabled={loadingBites}>
-              {loadingBites ? 'Extracting...' : 'Extract Viral Bites'}
-            </button>
-          )}
+          <h3><span className="step-num">1</span> Sticker Direction</h3>
+          <select
+            value={conceptMode}
+            onChange={(e) => setConceptMode(e.target.value)}
+            disabled={studioBusy}
+            className="studio-mode-select"
+            aria-label="Concept mode"
+          >
+            <option value="auto">Auto (best fit)</option>
+            <option value="phrase">Phrase-focused</option>
+            <option value="visual">Visual-focused</option>
+          </select>
         </div>
-        {loadingBites && (
+
+        {conceptMode === 'phrase' && (
+          <div className="studio-phrase-step">
+            <h4 className="studio-subheading">Phrase options</h4>
+            <p className="studio-hint">Pick distinct wordings first, then brainstorm sticker art.</p>
+            <button
+              type="button"
+              className="studio-action-btn secondary"
+              onClick={handleSuggestPhrases}
+              disabled={studioBusy}
+            >
+              {loadingPhrases ? 'Suggesting…' : 'Suggest phrase options'}
+            </button>
+            {phraseOptions.length > 0 && (
+              <div className="phrase-chips">
+                {phraseOptions.map((p, i) => (
+                  <button
+                    type="button"
+                    key={i}
+                    className={`phrase-chip ${selectedPhraseOption === p ? 'selected' : ''}`}
+                    onClick={() => setSelectedPhraseOption(p)}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          className="studio-action-btn"
+          onClick={handleGenerateConceptsFromTrend}
+          disabled={loadingConcepts || (conceptMode === 'phrase' && phraseOptions.length > 0 && !selectedPhraseOption)}
+        >
+          {loadingConcepts ? 'Brainstorming...' : 'Brainstorm sticker concepts'}
+        </button>
+        {(loadingConcepts || loadingPhrases) && (
           <div className="studio-loading">
             <div className="typing"><span></span><span></span><span></span></div>
-            <span>Finding viral phrases...</span>
+            <span>{loadingPhrases ? 'Generating phrase options…' : 'Generating sticker concepts…'}</span>
           </div>
         )}
-        {viralBites.length > 0 && (
-          <div className="bites-scroll">
-            {viralBites.map((bite, i) => {
-              const text = bite.text || bite.phrase || bite.bite || JSON.stringify(bite)
-              const source = bite.source_type || bite.source || bite.type || ''
-              const potential = bite.monetization_potential || bite.potential || ''
-              const isSelected = selectedBite === bite
-              return (
-                <div
-                  key={i}
-                  className={`bite-card ${isSelected ? 'selected' : ''}`}
-                  onClick={() => handleGenerateConcepts(bite)}
-                >
-                  <div className="bite-text">"{text}"</div>
-                  <div className="bite-meta">
-                    {source && <span className="bite-source">{source}</span>}
-                    {potential && <span className="bite-potential">{potential}</span>}
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        )}
+        {studioNotice && <div className="studio-note">{studioNotice}</div>}
       </section>
 
-      {/* Step 2: Sticker Concepts */}
       <section className="studio-section">
         <div className="studio-section-header">
           <h3><span className="step-num">2</span> Sticker Concepts</h3>
         </div>
-        {loadingConcepts && (
-          <div className="studio-loading">
-            <div className="typing"><span></span><span></span><span></span></div>
-            <span>Generating concepts...</span>
-          </div>
-        )}
-        {stickerIdeas.length > 0 && (
+        {stickerIdeas.length > 0 ? (
           <div className="concepts-grid">
             {stickerIdeas.map((concept, i) => {
               const style = concept.art_style || concept.style || ''
@@ -226,7 +312,7 @@ function StickerStudio({ onNavigateTrends }) {
                   <button
                     className="generate-image-btn"
                     onClick={() => handleGenerateImage(concept)}
-                    disabled={loadingImage}
+                    disabled={studioBusy || chatLoading}
                   >
                     {loadingImage && selectedConcept === concept ? 'Generating...' : 'Generate Image'}
                   </button>
@@ -234,10 +320,13 @@ function StickerStudio({ onNavigateTrends }) {
               )
             })}
           </div>
+        ) : (
+          !loadingConcepts && (
+            <p className="studio-hint">Concepts will appear here after you run “Brainstorm sticker concepts”.</p>
+          )
         )}
       </section>
 
-      {/* Step 3: Generated Stickers */}
       <section className="studio-section">
         <div className="studio-section-header">
           <h3><span className="step-num">3</span> Generated Stickers</h3>
@@ -251,15 +340,16 @@ function StickerStudio({ onNavigateTrends }) {
         {generatedStickers.length > 0 && (
           <div className="stickers-grid">
             {generatedStickers.map((filename, i) => (
-              <div key={i} className="generated-sticker-card">
+              <div key={`${filename}-${i}`} className="generated-sticker-card">
                 <img
-                  src={`http://localhost:8000/stickers/${filename}`}
+                  src={`${API_BASE}/stickers/${filename}`}
                   alt={`Sticker ${i + 1}`}
                   className="generated-sticker-img"
+                  onError={(e) => { e.target.style.opacity = 0.3 }}
                 />
                 <div className="sticker-actions">
                   <a
-                    href={`http://localhost:8000/stickers/${filename}`}
+                    href={`${API_BASE}/stickers/${filename}`}
                     download={filename}
                     className="download-btn"
                   >
@@ -270,7 +360,7 @@ function StickerStudio({ onNavigateTrends }) {
                     onClick={() => {
                       if (selectedConcept) handleGenerateImage(selectedConcept)
                     }}
-                    disabled={loadingImage}
+                    disabled={studioBusy}
                   >
                     Regenerate
                   </button>
@@ -281,7 +371,6 @@ function StickerStudio({ onNavigateTrends }) {
         )}
       </section>
 
-      {/* Refinement input */}
       <div className="studio-refinement">
         <div className="input-wrap">
           <textarea
@@ -291,12 +380,12 @@ function StickerStudio({ onNavigateTrends }) {
             onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleRefinement() } }}
             placeholder="Refine your stickers... (e.g. 'make it more pastel', 'add sparkles')"
             rows={1}
-            disabled={chatLoading}
+            disabled={studioBusy}
           />
           <button
             className="send-btn"
             onClick={handleRefinement}
-            disabled={!refinement.trim() || chatLoading}
+            disabled={!refinement.trim() || studioBusy}
             aria-label="Send refinement"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/frontend/src/components/TrendPulse.jsx
+++ b/frontend/src/components/TrendPulse.jsx
@@ -278,7 +278,8 @@ function TrendPulse({ onNavigateStudio }) {
   }
 
   const handleMakeStickers = (trend) => {
-    setSelectedTrend(trend)
+    const parent = searchTopic.trim() || undefined
+    setSelectedTrend(parent ? { ...trend, parent_topic: parent } : { ...trend })
     onNavigateStudio()
   }
 

--- a/miners/sentiment.py
+++ b/miners/sentiment.py
@@ -149,9 +149,11 @@ def analyze_emotions_gemini(texts: list[str], max_texts: int = 20) -> list[dict]
         f"Texts:\n{numbered}"
     )
 
+    from utils.llm_retry import sync_retry_llm
+
     model = GoogleModel("gemini-2.5-flash-lite", api_key=api_key)
     agent = Agent(model)
-    result = agent.run_sync(prompt)
+    result = sync_retry_llm(lambda: agent.run_sync(prompt))
 
     # Parse the JSON from the response
     raw = result.output

--- a/miners/trend_scorer.py
+++ b/miners/trend_scorer.py
@@ -36,6 +36,12 @@ _STOPWORDS = frozenset(
 )
 
 _MIN_WORD_LEN = 4  # ignore words shorter than this
+_GENERIC_TREND_WORDS = frozenset(
+    {
+        "stage", "technical", "issue", "festival", "performance", "crowd",
+        "music", "artist", "lineup", "weekend", "show", "set", "vibe",
+    }
+)
 
 
 def _tokenize(text: str) -> list[str]:
@@ -92,9 +98,17 @@ def _cluster_posts(posts: list[dict]) -> dict[str, list[dict]]:
             cluster_posts.append(posts[idx])
             word_counts.update(_tokenize(posts[idx].get("title", "")))
 
-        # Pick top 2-3 words as the cluster name
-        top_words = [w for w, _ in word_counts.most_common(3)]
-        name = " ".join(top_words) if top_words else f"cluster_{cid}"
+        # Prefer an event-like title for naming to avoid generic labels.
+        top_post = max(cluster_posts, key=lambda p: p.get("score", 0), default={})
+        top_title = (top_post.get("title", "") or "").strip()
+        title_tokens = [w for w in _tokenize(top_title) if w not in _GENERIC_TREND_WORDS]
+
+        if top_title and len(title_tokens) >= 2:
+            words = top_title.split()
+            name = " ".join(words[:8]).strip(" -:;,.!?")
+        else:
+            top_words = [w for w, _ in word_counts.most_common(6) if w not in _GENERIC_TREND_WORDS]
+            name = " ".join(top_words[:3]) if top_words else f"cluster_{cid}"
         named_clusters[name] = cluster_posts
 
     return named_clusters

--- a/miners/web_search_miner.py
+++ b/miners/web_search_miner.py
@@ -31,7 +31,10 @@ from pydantic_ai.providers.google import GoogleProvider
 
 # Load env from project root
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
 load_dotenv(_PROJECT_ROOT / ".env")
+
+from utils.llm_retry import sync_retry_llm
 
 DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 
@@ -192,7 +195,7 @@ def mine_web_search(query: str, *, model_name: str = DEFAULT_MODEL) -> dict:
         f"Focus on content from the last 7 days. Today is {now.strftime('%B %d, %Y')}."
     )
 
-    run = agent.run_sync(user_prompt)
+    run = sync_retry_llm(lambda: agent.run_sync(user_prompt))
     messages = run.all_messages()
 
     # Get grounding URLs from the raw message exchange

--- a/schemas/sticker.py
+++ b/schemas/sticker.py
@@ -38,3 +38,11 @@ class StickerIdeaSet(BaseModel):
 
     viral_bite: str = Field(description="The viral bite these sticker ideas are based on")
     ideas: list[StickerIdea] = Field(description="Generated sticker concepts (typically 3-5 per bite)")
+
+
+class PhraseOptionSet(BaseModel):
+    """Distinct phrase options before styling (Studio phrase-focused step)."""
+
+    phrases: list[str] = Field(
+        description="Exactly 5 distinct short sticker phrases (different wordings, same cultural moment)"
+    )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Project utilities."""

--- a/utils/llm_retry.py
+++ b/utils/llm_retry.py
@@ -1,0 +1,84 @@
+"""Retry helpers for transient Gemini / Google AI errors (503, 429, overload)."""
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def is_transient_gemini_error(exc: BaseException) -> bool:
+    """True if retrying the same request may succeed."""
+    s = str(exc).lower()
+    if any(x in s for x in ("503", "429", "502", "504")):
+        return True
+    if "unavailable" in s and ("model" in s or "service" in s):
+        return True
+    if "resource_exhausted" in s:
+        return True
+    if "rate" in s and "limit" in s:
+        return True
+    if "overloaded" in s or "try again later" in s:
+        return True
+
+    code = getattr(exc, "status_code", None)
+    if code in (429, 502, 503, 504):
+        return True
+
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        err = body.get("error") or {}
+        status = (err.get("status") or "").upper()
+        if status in ("UNAVAILABLE", "RESOURCE_EXHAUSTED", "DEADLINE_EXCEEDED"):
+            return True
+        msg = str(err.get("message", "")).lower()
+        if "try again" in msg or "high demand" in msg:
+            return True
+    return False
+
+
+async def async_retry_llm(
+    factory: Callable[[], Awaitable[T]],
+    *,
+    max_attempts: int = 6,
+    base_delay: float = 1.5,
+    max_delay: float = 45.0,
+) -> T:
+    """Retry an async LLM call with exponential backoff + jitter."""
+    last: BaseException | None = None
+    for attempt in range(max_attempts):
+        try:
+            return await factory()
+        except Exception as e:
+            last = e
+            if not is_transient_gemini_error(e) or attempt == max_attempts - 1:
+                raise
+            delay = min(max_delay, base_delay * (2**attempt) + random.uniform(0, 0.75))
+            await asyncio.sleep(delay)
+    assert last is not None
+    raise last
+
+
+def sync_retry_llm(
+    factory: Callable[[], T],
+    *,
+    max_attempts: int = 6,
+    base_delay: float = 1.5,
+    max_delay: float = 45.0,
+) -> T:
+    """Retry a sync LLM call with exponential backoff + jitter."""
+    last: BaseException | None = None
+    for attempt in range(max_attempts):
+        try:
+            return factory()
+        except Exception as e:
+            last = e
+            if not is_transient_gemini_error(e) or attempt == max_attempts - 1:
+                raise
+            delay = min(max_delay, base_delay * (2**attempt) + random.uniform(0, 0.75))
+            time.sleep(delay)
+    assert last is not None
+    raise last


### PR DESCRIPTION
Expose /api/studio/brainstorm, suggest-phrases, and generate-image so the React Studio gets structured JSON without relying on the chat agent. Wire Sticker Studio to those endpoints, add parent-topic passthrough from Trend Pulse, phrase-first flow, and Gemini retry/fallback helpers. Harden chat tool-result extraction for ToolReturnPart, tune sticker copy, and improve trend naming.

Made-with: Cursor